### PR TITLE
fix: add null checks for getTargetException() in 3 methods to prevent NPE

### DIFF
--- a/src/main/java/org/solenopsis/session/soap/util/SoapExceptionUtil.java
+++ b/src/main/java/org/solenopsis/session/soap/util/SoapExceptionUtil.java
@@ -112,7 +112,8 @@ public class SoapExceptionUtil {
      */
     public static boolean isFunctionTemporarilyUnavailable(final InvocationTargetException exception) {
         // Nope, get the cause and try again.
-        return isFunctionTemporarilyUnavailable(exception.getTargetException().getMessage());
+        final Throwable target = exception.getTargetException();
+        return (target == null) ? false : isFunctionTemporarilyUnavailable(target.getMessage());
     }
 
     /**
@@ -153,7 +154,8 @@ public class SoapExceptionUtil {
      * @param failure is the failure to examine for an invalid session id.
      */
     public static boolean isInvalidSessionId(final InvocationTargetException failure) {
-        return isInvalidSessionId(failure.getTargetException().getMessage());
+        final Throwable target = failure.getTargetException();
+        return (target == null) ? false : isInvalidSessionId(target.getMessage());
     }
 
     /**
@@ -191,8 +193,9 @@ public class SoapExceptionUtil {
      *
      * @return true if throwable is an IOException or false if not.
      */
-    public static  boolean isInvalidQueryLocator(final InvocationTargetException exception) {
-        return isInvalidQueryLocator(exception.getTargetException().getMessage());
+    public static boolean isInvalidQueryLocator(final InvocationTargetException exception) {
+        final Throwable target = exception.getTargetException();
+        return (target == null) ? false : isInvalidQueryLocator(target.getMessage());
     }
 
     /**


### PR DESCRIPTION
## Summary
Add null safety checks to 3 methods in `SoapExceptionUtil.java` that call `getTargetException().getMessage()` without checking if `getTargetException()` returns null.

## Changes (1 file, 3 methods fixed)

1. **`isFunctionTemporarilyUnavailable`** (line ~115): Added null check on target exception
2. **`isInvalidSessionId`** (line ~156): Added null check on target exception  
3. **`isInvalidQueryLocator`** (line ~195): Added null check on target exception (also fixes double-space before `boolean`)

## Fix pattern
```java
// Before
return isInvalidQueryLocator(exception.getTargetException().getMessage());

// After
final Throwable target = exception.getTargetException();
return (target == null) ? false : isInvalidQueryLocator(target.getMessage());
```

## Fixes
- Fixes #39 (isFunctionTemporarilyUnavailable NPE)
- Fixes #36 (isInvalidSessionId NPE)
- Fixes #35 (isInvalidQueryLocator NPE)
